### PR TITLE
chore(security): move Mistral API key to .env; remove .env.example; r…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-MISTRAL_API_KEY=<paste-your-key-here>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Mistral 7B Chat (FastAPI Proxy) 🎯
+
+**Overview**  
+Tiny backend that proxies the official **Mistral AI** API:
+
+- `GET /health` — quick readiness check  
+- `GET /models` — list available models  
+- `POST /chat` — chat completion endpoint  
+
+A minimal `index.html` is included — a simple browser chat that talks to the local backend.
+
+---
+
+## 🧠 Stack
+
+- **Language model:** `open-mistral-7b`  
+- **Backend:** Python 3.10+, FastAPI + Uvicorn  
+- **API client:** `httpx` (you can swap for `mistralai` SDK)  
+- **(Optional) RAG:** `mistral-embed` + Qdrant via `/ingest` and `/query_rag` (if implemented in `app.py`)
+
+---
+
+## 🚀 Run locally
+./.venv/Scripts/python -m uvicorn app:app --reload --port 8000

--- a/app.py
+++ b/app.py
@@ -1,20 +1,14 @@
-# app.py
-# Minimal FastAPI proxy to Mistral's /v1/chat/completions with non-streaming calls.
-# Comments are in English per your request.
-
-import httpx
+import os, httpx
+from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import List, Literal, Optional
 
-# Hardcoded API key (you asked to keep it in code explicitly).
-MISTRAL_API_KEY = "0IAClm1qBDX927s7mGD61pegnbiFQEJe"
-
-# Base URL for Mistral API
+# Mistral API
+load_dotenv()
+MISTRAL_API_KEY = os.environ["LMA_MISTRAL_API_KEY"]
 MISTRAL_URL = "https://api.mistral.ai/v1"
-
-# Default 7B model (adjust if your account lists a different name in /v1/models)
 DEFAULT_MODEL = "open-mistral-7b"
 
 app = FastAPI(title="Mistral Chat Proxy")

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 
     function render() {
       log.textContent = history
-        .map(m => (m.role === "user" ? "Вы: " : "Модель: ") + m.content)
+        .map(m => (m.role === "user" ? "You: " : "AI: ") + m.content)
         .join("\n\n");
     }
 


### PR DESCRIPTION
…ead via dotenv (LMA_MISTRAL_API_KEY)